### PR TITLE
Add initial implementation of NOPE package

### DIFF
--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 58b9abf25396747c592fb8a1d7f69ba4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 444c85e521425448c9cc213324d4419f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Maybe.cs
+++ b/Runtime/Maybe.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace NOPE.Runtime
+{
+    /// <summary>
+    /// Represents an optional value: either it has a value (of type T) or it does not (None).
+    /// </summary>
+    public readonly struct Maybe<T>
+    {
+        private readonly bool _hasValue;
+        private readonly T _value;
+
+        private Maybe(T value, bool hasValue)
+        {
+            _value = value;
+            _hasValue = hasValue;
+        }
+
+        /// <summary>
+        /// Whether this maybe actually contains a value.
+        /// </summary>
+        public bool HasValue => _hasValue;
+
+        /// <summary>
+        /// Whether this maybe does not contain a value.
+        /// </summary>
+        public bool HasNoValue => !_hasValue;
+
+        /// <summary>
+        /// Returns the contained value if it exists; otherwise throws an exception.
+        /// </summary>
+        public T Value => _hasValue
+            ? _value
+            : throw new InvalidOperationException("No value in Maybe.");
+
+        /// <summary>
+        /// Constructs a Maybe from a given value (if non-null).
+        /// If the value is null, returns None.
+        /// </summary>
+        public static Maybe<T> From(T value)
+        {
+            if (value == null)
+                return None;
+            return new Maybe<T>(value, true);
+        }
+
+        /// <summary>
+        /// A Maybe that has no value.
+        /// </summary>
+        public static Maybe<T> None => new Maybe<T>(default, false);
+
+        /// <summary>
+        /// Implicitly converts a value of type T to Maybe&lt;T&gt; (useful for direct returns).
+        /// </summary>
+        public static implicit operator Maybe<T>(T value) => From(value);
+    }
+}

--- a/Runtime/Maybe.cs.meta
+++ b/Runtime/Maybe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a264a06799b4748a4942953e90c53d40

--- a/Runtime/NOPE.Runtime.asmdef
+++ b/Runtime/NOPE.Runtime.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "NOPE.Runtime",
+    "rootNamespace": "NOPE.Runtime",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Runtime/NOPE.Runtime.asmdef.meta
+++ b/Runtime/NOPE.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 97b022c34fbe341488ec42b61e690735
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Result.cs
+++ b/Runtime/Result.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace NOPE.Runtime
+{
+    /// <summary>
+    /// Represents the outcome of an operation that can either succeed (with a value)
+    /// or fail (with an error message).
+    /// </summary>
+    public readonly struct Result<T>
+    {
+        private readonly T _value;
+        private readonly string _error;
+
+        private Result(bool isSuccess, T value, string error)
+        {
+            IsSuccess = isSuccess;
+            _value = value;
+            _error = error;
+        }
+
+        /// <summary>
+        /// Whether this result represents a successful outcome.
+        /// </summary>
+        public bool IsSuccess { get; }
+
+        /// <summary>
+        /// Whether this result represents a failed outcome.
+        /// </summary>
+        public bool IsFailure => !IsSuccess;
+
+        /// <summary>
+        /// The value of the result if it is successful; otherwise throws an exception.
+        /// </summary>
+        public T Value => IsSuccess
+            ? _value
+            : throw new InvalidOperationException("Attempted to access Value of a failed Result.");
+
+        /// <summary>
+        /// The error message of the result if it is failed; otherwise throws an exception.
+        /// </summary>
+        public string Error => IsFailure
+            ? _error
+            : throw new InvalidOperationException("Attempted to access Error of a successful Result.");
+
+        /// <summary>
+        /// Creates a successful result with the given value.
+        /// </summary>
+        public static Result<T> Success(T value)
+            => new Result<T>(true, value, default);
+
+        /// <summary>
+        /// Creates a failed result with the given error message.
+        /// </summary>
+        public static Result<T> Failure(string error)
+            => new Result<T>(false, default, error);
+
+        /// <summary>
+        /// Implicitly converts a value of type T to a successful Result.
+        /// </summary>
+        public static implicit operator Result<T>(T value) => Success(value);
+
+        /// <summary>
+        /// Implicitly converts a string to a failed Result (for convenience).
+        /// </summary>
+        public static implicit operator Result<T>(string error) => Failure(error);
+    }
+}

--- a/Runtime/Result.cs.meta
+++ b/Runtime/Result.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e629cfbe59adf4c3db82819f1e8bad7b

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 735f153c4e6df4c9d914d39bd63cdb3c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/BasicTests.cs
+++ b/Tests/BasicTests.cs
@@ -1,0 +1,99 @@
+using NOPE.Runtime;
+using NUnit.Framework;
+
+namespace NOPE.Tests
+{
+    public class BasicTests
+    {
+        [Test]
+        public void Result_Success_ShouldCreateValidResult()
+        {
+            // Arrange & Act
+            var r = Result<int>.Success(5);
+
+            // Assert
+            Assert.IsTrue(r.IsSuccess);
+            Assert.IsFalse(r.IsFailure);
+            Assert.AreEqual(5, r.Value);
+            // IsSuccess 시 Error 프로퍼티에 접근하면 예외가 떠야 함
+            Assert.Throws<System.InvalidOperationException>(() =>
+            {
+                var _ = r.Error;
+            });
+        }
+
+        [Test]
+        public void Result_Failure_ShouldCreateFailedResult()
+        {
+            // Arrange & Act
+            var r = Result<int>.Failure("Something went wrong");
+
+            // Assert
+            Assert.IsFalse(r.IsSuccess);
+            Assert.IsTrue(r.IsFailure);
+            Assert.AreEqual("Something went wrong", r.Error);
+            // IsFailure 시 Value 프로퍼티에 접근하면 예외가 떠야 함
+            Assert.Throws<System.InvalidOperationException>(() =>
+            {
+                var _ = r.Value;
+            });
+        }
+
+        [Test]
+        public void Result_ImplicitConversions_ShouldWork()
+        {
+            // 암시적 변환: T -> Success
+            Result<int> r1 = 123;
+            Assert.IsTrue(r1.IsSuccess);
+            Assert.AreEqual(123, r1.Value);
+
+            // 암시적 변환: string -> Failure
+            Result<int> r2 = "Error occurred";
+            Assert.IsFalse(r2.IsSuccess);
+            Assert.AreEqual("Error occurred", r2.Error);
+        }
+
+        [Test]
+        public void Maybe_From_ShouldCreateCorrectMaybe()
+        {
+            // Arrange & Act
+            var maybeWithValue = Maybe<string>.From("Hello");
+            var maybeNone = Maybe<string>.From(null);
+
+            // Assert
+            Assert.IsTrue(maybeWithValue.HasValue);
+            Assert.AreEqual("Hello", maybeWithValue.Value);
+
+            Assert.IsFalse(maybeNone.HasValue);
+            Assert.Throws<System.InvalidOperationException>(() =>
+            {
+                var _ = maybeNone.Value;
+            });
+        }
+
+        [Test]
+        public void Maybe_None_ShouldBeNoValue()
+        {
+            // Arrange
+            var none = Maybe<int>.None;
+
+            // Assert
+            Assert.IsFalse(none.HasValue);
+            Assert.IsTrue(none.HasNoValue);
+        }
+
+        [Test]
+        public void Maybe_ImplicitConversion_ShouldWork()
+        {
+            // Arrange & Act
+            Maybe<int> maybe123 = 123;  // implicit
+            Maybe<int> maybeNone = Maybe<int>.None;
+
+            // Assert
+            Assert.IsTrue(maybe123.HasValue);
+            Assert.AreEqual(123, maybe123.Value);
+
+            Assert.IsFalse(maybeNone.HasValue);
+        }
+    }
+}

--- a/Tests/BasicTests.cs.meta
+++ b/Tests/BasicTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 548b923b2851f406caab8f9c3e897bc0

--- a/Tests/NOPE.Tests.asmdef
+++ b/Tests/NOPE.Tests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "NOPE.Tests",
+    "rootNamespace": "NOPE",
+    "references": [
+        "NOPE.Runtime",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/NOPE.Tests.asmdef.meta
+++ b/Tests/NOPE.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e95cc4190acb84147a925f75d969d3f2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "com.kwanjoong.nope",
+  "version": "0.1.0",
+  "displayName": "Unity NOPE",
+  "description": "No Overused Possibly Evil exceptions.",
+  "unity": "2022.3",
+  "documentationUrl": "https://kwanjoong-dev.gitbook.io/unity-ui-storyboard",
+  "keywords": [
+    "result",
+    "exception",
+    "error",
+    "nope",
+    "functional"
+  ],
+  "author": {
+    "name": "Kwanjoong Lee",
+    "url": "https://github.com/kwan3854"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kwan3854/Unity-NOPE.git"
+  },
+  "dependencies": {
+
+  },
+  "license": "MIT"
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e075d58fa81804acd890482ad6017bb9
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Created core structures: `Maybe<T>` and `Result<T>` for handling optional values and operation outcomes.
- Added tests to validate functionality of `Maybe` and `Result`.
- Included metadata files for package configuration.
- Set up basic project structure with necessary assembly definitions.