### PR TITLE
2 add core extension methods

### DIFF
--- a/Runtime/MaybeExtensions.cs
+++ b/Runtime/MaybeExtensions.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace NOPE.Runtime
+{
+    /// <summary>
+    /// Provides extension methods for Maybe&lt;T&gt; to enable functional-style chaining.
+    /// </summary>
+    public static class MaybeExtensions
+    {
+        /// <summary>
+        /// Projects the inner value to a new form if present; otherwise returns None.
+        /// </summary>
+        public static Maybe<TNew> Map<TOriginal, TNew>(
+            this Maybe<TOriginal> maybe,
+            Func<TOriginal, TNew> selector)
+        {
+            return maybe.HasValue
+                ? Maybe<TNew>.From(selector(maybe.Value))
+                : Maybe<TNew>.None;
+        }
+
+        /// <summary>
+        /// Converts the inner value into another Maybe if present; otherwise returns None.
+        /// (similar to Bind/flatMap)
+        /// </summary>
+        public static Maybe<TNew> Bind<TOriginal, TNew>(
+            this Maybe<TOriginal> maybe,
+            Func<TOriginal, Maybe<TNew>> binder)
+        {
+            return maybe.HasValue
+                ? binder(maybe.Value)
+                : Maybe<TNew>.None;
+        }
+
+        /// <summary>
+        /// Executes the given action if there is a value; otherwise does nothing.
+        /// Returns the original maybe unmodified.
+        /// </summary>
+        public static Maybe<T> Tap<T>(
+            this Maybe<T> maybe,
+            Action<T> action)
+        {
+            if (maybe.HasValue)
+            {
+                action(maybe.Value);
+            }
+            return maybe;
+        }
+
+        /// <summary>
+        /// Converts a Maybe to a single value by providing two functions:
+        /// one for when there is a value, and one for when there is not.
+        /// </summary>
+        public static TResult Match<T, TResult>(
+            this Maybe<T> maybe,
+            Func<T, TResult> onValue,
+            Func<TResult> onNone)
+        {
+            return maybe.HasValue
+                ? onValue(maybe.Value)
+                : onNone();
+        }
+    }
+}

--- a/Runtime/MaybeExtensions.cs.meta
+++ b/Runtime/MaybeExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1b0e21c326e3e4ebea9e674485eca35f

--- a/Runtime/ResultExtensions.cs
+++ b/Runtime/ResultExtensions.cs
@@ -1,0 +1,98 @@
+using System;
+
+namespace NOPE.Runtime
+{
+    /// <summary>
+    /// Provides extension methods for Result&lt;T&gt; to enable functional-style chaining.
+    /// </summary>
+    public static class ResultExtensions
+    {
+        /// <summary>
+        /// Projects the value of a successful Result into a new form.
+        /// If the Result is failure, returns a new Result with the same error.
+        /// </summary>
+        public static Result<TNew> Map<TOriginal, TNew>(
+            this Result<TOriginal> result,
+            Func<TOriginal, TNew> selector)
+        {
+            return result.IsSuccess
+                ? Result<TNew>.Success(selector(result.Value))
+                : Result<TNew>.Failure(result.Error);
+        }
+
+        /// <summary>
+        /// Converts the value of a successful Result into another Result.
+        /// (aka 'flatMap' or 'SelectMany')
+        /// If the current Result is failure, returns a new Result with the same error.
+        /// </summary>
+        public static Result<TNew> Bind<TOriginal, TNew>(
+            this Result<TOriginal> result,
+            Func<TOriginal, Result<TNew>> binder)
+        {
+            return result.IsSuccess
+                ? binder(result.Value)
+                : Result<TNew>.Failure(result.Error);
+        }
+
+        /// <summary>
+        /// Executes the given action if the Result is successful, then returns the original Result as-is.
+        /// (Useful for "do something" side-effects without changing the type)
+        /// </summary>
+        public static Result<T> Tap<T>(
+            this Result<T> result,
+            Action<T> action)
+        {
+            if (result.IsSuccess)
+            {
+                action(result.Value);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// If this Result is successful but fails the predicate, transforms it into a failure with the given error message.
+        /// Otherwise, returns the original Result.
+        /// </summary>
+        public static Result<T> Ensure<T>(
+            this Result<T> result,
+            Func<T, bool> predicate,
+            string errorMessage)
+        {
+            if (result.IsSuccess && !predicate(result.Value))
+            {
+                return Result<T>.Failure(errorMessage);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms a Result into a single value by providing two functions:
+        /// one for handling success, and one for handling failure.
+        /// </summary>
+        public static TResult Match<T, TResult>(
+            this Result<T> result,
+            Func<T, TResult> onSuccess,
+            Func<string, TResult> onFailure)
+        {
+            return result.IsSuccess
+                ? onSuccess(result.Value)
+                : onFailure(result.Error);
+        }
+
+        /// <summary>
+        /// If the Result is failure, applies a function to the error message to produce a new error.
+        /// Otherwise, returns the original success.
+        /// </summary>
+        public static Result<T> MapError<T>(
+            this Result<T> result,
+            Func<string, string> errorSelector)
+        {
+            if (result.IsFailure)
+            {
+                var transformed = errorSelector(result.Error);
+                return Result<T>.Failure(transformed);
+            }
+            return result;
+        }
+    }
+}

--- a/Runtime/ResultExtensions.cs.meta
+++ b/Runtime/ResultExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e43bc70b6f244457990cfc756d37c2ae

--- a/Tests/ResultExtensionsTests.cs
+++ b/Tests/ResultExtensionsTests.cs
@@ -1,0 +1,127 @@
+using NOPE.Runtime;
+using NUnit.Framework;
+
+namespace NOPE.Tests
+{
+    public class ResultExtensionsTests
+    {
+        [Test]
+        public void Map_Success_TransformsValue()
+        {
+            var r = Result<int>.Success(10);
+            var mapped = r.Map(x => x * 3);
+            Assert.IsTrue(mapped.IsSuccess);
+            Assert.AreEqual(30, mapped.Value);
+        }
+
+        [Test]
+        public void Map_Failure_RetainsError()
+        {
+            var r = Result<int>.Failure("Oops");
+            var mapped = r.Map(x => x * 3);
+            Assert.IsTrue(mapped.IsFailure);
+            Assert.AreEqual("Oops", mapped.Error);
+        }
+
+        [Test]
+        public void Bind_Success_TransformsToNewResult()
+        {
+            var r = Result<int>.Success(10);
+            var bound = r.Bind(x => Result<string>.Success((x * 3).ToString()));
+            Assert.IsTrue(bound.IsSuccess);
+            Assert.AreEqual("30", bound.Value);
+        }
+
+        [Test]
+        public void Bind_Failure_RetainsError()
+        {
+            var r = Result<int>.Failure("Oops");
+            var bound = r.Bind(x => Result<string>.Success((x * 3).ToString()));
+            Assert.IsTrue(bound.IsFailure);
+            Assert.AreEqual("Oops", bound.Error);
+        }
+
+        [Test]
+        public void Tap_Success_ExecutesAction()
+        {
+            var r = Result<int>.Success(10);
+            var tapped = false;
+            r.Tap(x => tapped = true);
+            Assert.IsTrue(tapped);
+        }
+
+        [Test]
+        public void Tap_Failure_DoesNotExecuteAction()
+        {
+            var r = Result<int>.Failure("Oops");
+            var tapped = false;
+            r.Tap(x => tapped = true);
+            Assert.IsFalse(tapped);
+        }
+
+        [Test]
+        public void Ensure_Success_PredicateTrue_ReturnsOriginal()
+        {
+            var r = Result<int>.Success(10);
+            var ensured = r.Ensure(x => x > 5, "Value is too small");
+            Assert.IsTrue(ensured.IsSuccess);
+            Assert.AreEqual(10, ensured.Value);
+        }
+
+        [Test]
+        public void Ensure_Success_PredicateFalse_ReturnsFailure()
+        {
+            var r = Result<int>.Success(10);
+            var ensured = r.Ensure(x => x > 15, "Value is too small");
+            Assert.IsTrue(ensured.IsFailure);
+            Assert.AreEqual("Value is too small", ensured.Error);
+        }
+
+        [Test]
+        public void Ensure_Failure_RetainsError()
+        {
+            var r = Result<int>.Failure("Oops");
+            var ensured = r.Ensure(x => x > 5, "Value is too small");
+            Assert.IsTrue(ensured.IsFailure);
+            Assert.AreEqual("Oops", ensured.Error);
+        }
+
+        [Test]
+        public void Match_Success_ExecutesOnSuccess()
+        {
+            var r = Result<int>.Success(10);
+            var result = r.Match(
+                onSuccess: x => x * 2,
+                onFailure: err => -1);
+            Assert.AreEqual(20, result);
+        }
+
+        [Test]
+        public void Match_Failure_ExecutesOnFailure()
+        {
+            var r = Result<int>.Failure("Oops");
+            var result = r.Match(
+                onSuccess: x => x * 2,
+                onFailure: err => -1);
+            Assert.AreEqual(-1, result);
+        }
+
+        [Test]
+        public void MapError_Failure_TransformsError()
+        {
+            var r = Result<int>.Failure("Oops");
+            var mappedError = r.MapError(err => err.ToUpper());
+            Assert.IsTrue(mappedError.IsFailure);
+            Assert.AreEqual("OOPS", mappedError.Error);
+        }
+
+        [Test]
+        public void MapError_Success_RetainsValue()
+        {
+            var r = Result<int>.Success(10);
+            var mappedError = r.MapError(err => err.ToUpper());
+            Assert.IsTrue(mappedError.IsSuccess);
+            Assert.AreEqual(10, mappedError.Value);
+        }
+    }
+}

--- a/Tests/ResultExtensionsTests.cs.meta
+++ b/Tests/ResultExtensionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0f60084b3ac840b1ad4fea0426d5948


### PR DESCRIPTION
# Add functional-style extensions for Maybe and Result
- Introduced extension methods for Maybe to support mapping, binding, tapping, and matching.
- Added similar extension methods for Result with additional error handling capabilities.
- Enhanced functional programming style in the codebase.

# Add unit tests for result extension methods
- Implement tests for mapping, binding, and tapping success/failure scenarios.
- Ensure error handling is validated through various predicates.
- Test matching behavior for both success and failure cases.
- Include error transformation checks.