### PR TITLE
V1.0.3

### DIFF
--- a/.idea/.idea.UnityNope/.idea/vcs.xml
+++ b/.idea/.idea.UnityNope/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/Packages/Unity-NOPE" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/Assets/Tests/CollectionUtilitiesExtensionsTests.cs
+++ b/Assets/Tests/CollectionUtilitiesExtensionsTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using NOPE.Runtime;
 using NOPE.Runtime.Core;
 using NOPE.Runtime.Core.Maybe;
@@ -196,5 +198,20 @@ namespace NOPE.Tests
             maybe.ExecuteNoValue(() => count++);
             Assert.AreEqual(1, count);
         }
+        
+#if NOPE_UNITASK
+        [Test]
+        public async Task TryFindAsync_UniTask()
+        {
+            var unAwaitedDict = GetAsyncUniTaskDictionary();
+            var maybe = await unAwaitedDict.TryFind("test");
+        }
+
+        private async UniTask<IDictionary<string, int>> GetAsyncUniTaskDictionary()
+        {
+            await UniTask.Yield();
+            return new Dictionary<string, int> { { "test", 42 } };
+        }
+#endif
     }
 }

--- a/Assets/Tests/MaybeAsyncExtensionsTests.cs
+++ b/Assets/Tests/MaybeAsyncExtensionsTests.cs
@@ -289,6 +289,22 @@ namespace NOPE.Tests
 
             Assert.IsFalse(result.HasValue);
         }
+        
+        [Test]
+        public async System.Threading.Tasks.Task Bind_Awaitable_ShouldReturnNone_WhenMaybeHasNoValue_2()
+        {
+            var cts = CreateMaybe(null);
+            var maybe = cts.Awaitable;
+
+            var result = await maybe.Bind(async x =>
+            {
+                await Task.Delay(1); // simulate some async operation
+                
+                return Maybe<string>.From(x.ToString());
+            });
+
+            Assert.IsFalse(result.HasValue);
+        }
 
         [Test]
         public async System.Threading.Tasks.Task Tap_Awaitable_ShouldExecuteAction_WhenMaybeHasValue()

--- a/Assets/Tests/PracticalTests.cs
+++ b/Assets/Tests/PracticalTests.cs
@@ -46,20 +46,24 @@ namespace NOPE.Tests
         public void SuccessIf_And_FailureIf()
         {
             var r = Result.SuccessIf(condition: () => DateTime.Now.Year > 2000,
-                                     resultValue: 999,
-                                     error: "Year <= 2000?");
+                                     999,
+                                     "Year <= 2000?");
             Assert.IsTrue(r.IsSuccess); 
 
             var r2 = Result.FailureIf(true, 123, "Condition triggered fail");
             Assert.IsTrue(r2.IsFailure);
             Assert.AreEqual("Condition triggered fail", r2.Error);
         }
-
+        
         [Test]
         public void Of_WrapsExceptions()
         {
-            var res = Result.Of<int,string>(
-                () => throw new InvalidOperationException("IOEx"),
+            var res = Result.Of(
+                () =>
+                {
+                    throw new InvalidOperationException("IOEx");
+                    return 100;
+                },
                 ex => $"Ex: {ex.Message}");
             Assert.IsTrue(res.IsFailure);
             Assert.AreEqual("Ex: IOEx", res.Error);
@@ -199,6 +203,19 @@ namespace NOPE.Tests
         }
         
 #if NOPE_UNITASK
+        [Test]
+        public async Task Async_SuccessIf()
+        {
+            var r = await Result.SuccessIf(conditionAsync: async () =>
+                {
+                    await UniTask.Delay(1);
+                    return DateTime.Now.Year > 2000;
+                },
+                999,
+                "Year <= 2000?");
+            Assert.IsTrue(r.IsSuccess);
+        }
+        
         // 5) Async usage (UniTask)
         [Test]
         public async Task Async_Chain_Result()

--- a/Assets/Tests/PracticalTests.cs
+++ b/Assets/Tests/PracticalTests.cs
@@ -266,6 +266,42 @@ namespace NOPE.Tests
             }
             return result;
         }
+        
+        [Test]
+        public async Task CombineValues_Async_UniTask()
+        {
+            var r1 = SlowSuccess(10);
+            var r2 = SlowSuccess(20);
+            var combined = await Result.CombineValues(r1, r2);
+            Assert.IsTrue(combined.IsSuccess);
+            Assert.AreEqual(10, combined.Value.Item1);
+            Assert.AreEqual(20, combined.Value.Item2);
+            
+            // 10 Tuple
+            var tenTuple = await Result.CombineValues(
+                SlowSuccess(10),
+                SlowSuccess(20),
+                SlowSuccess(10),
+                SlowSuccess(20),
+                SlowSuccess(10),
+                SlowSuccess(20),
+                SlowSuccess(10),
+                SlowSuccess(20),
+                SlowSuccess(10),
+                SlowSuccess(20));
+            Assert.IsTrue(tenTuple.IsSuccess);
+            Assert.AreEqual(10, tenTuple.Value.Length);
+            Assert.AreEqual(10, tenTuple.Value[0]);
+            Assert.AreEqual(20, tenTuple.Value[1]);
+            Assert.AreEqual(10, tenTuple.Value[2]);
+            Assert.AreEqual(20, tenTuple.Value[3]);
+            Assert.AreEqual(10, tenTuple.Value[4]);
+            Assert.AreEqual(20, tenTuple.Value[5]);
+            Assert.AreEqual(10, tenTuple.Value[6]);
+            Assert.AreEqual(20, tenTuple.Value[7]);
+            Assert.AreEqual(10, tenTuple.Value[8]);
+            Assert.AreEqual(20, tenTuple.Value[9]);
+        }
 #endif
 
 #if NOPE_AWAITABLE

--- a/Assets/Tests/ResultTests.cs
+++ b/Assets/Tests/ResultTests.cs
@@ -100,6 +100,151 @@ namespace NOPE.Tests
             Assert.AreEqual("FAIL", r.Error);
         }
     }
+    
+    [TestFixture]
+    public class ResultTests_FactoryMethods
+    {
+        [Test]
+        public void SuccessFactoryMethod()
+        {
+            var r = Result<int, string>.Success(123);
+
+            Assert.IsTrue(r.IsSuccess);
+            Assert.AreEqual(123, r.Value);
+        }
+
+        [Test]
+        public void FailureFactoryMethod()
+        {
+            var r = Result<int, string>.Failure("ERR");
+
+            Assert.IsTrue(r.IsFailure);
+            Assert.AreEqual("ERR", r.Error);
+        }
+
+        [Test]
+        public void ImplicitSuccessFactoryMethod()
+        {
+            Result<int, string> r = 999;
+
+            Assert.IsTrue(r.IsSuccess);
+            Assert.AreEqual(999, r.Value);
+        }
+
+        [Test]
+        public void ImplicitFailureFactoryMethod()
+        {
+            Result<int, string> r = "ERR";
+
+            Assert.IsTrue(r.IsFailure);
+            Assert.AreEqual("ERR", r.Error);
+        }
+        
+        [Test]
+        public void SuccessIfFactoryMethod_Success()
+        {
+            var r = Result.SuccessIf(123 > 100, 123, "ERR");
+
+            Assert.IsTrue(r.IsSuccess);
+            Assert.AreEqual(123, r.Value);
+        }
+        
+        [Test]
+        public void SuccessIfFactoryMethod_Failure()
+        {
+            var r = Result.SuccessIf(123 < 100, 123, "ERR");
+
+            Assert.IsTrue(r.IsFailure);
+            Assert.AreEqual("ERR", r.Error);
+        }
+        
+        [Test]
+        public void FailureIfFactoryMethod_Success()
+        {
+            var r = Result.FailureIf(123 < 100, 123, "ERR");
+
+            Assert.IsTrue(r.IsSuccess);
+            Assert.AreEqual(123, r.Value);
+        }
+        
+        [Test]
+        public void FailureIfFactoryMethod_Failure()
+        {
+            var r = Result.FailureIf(123 > 100, 123, "ERR");
+
+            Assert.IsTrue(r.IsFailure);
+            Assert.AreEqual("ERR", r.Error);
+        }
+
+#if NOPE_UNITASK
+        [Test]
+        public async Task SuccessIfFactoryMethod_Async()
+        {
+            var r = await Result.SuccessIf(async () =>
+            {
+                await UniTask.Delay(1);
+                return 123 > 100;
+            }, 123, "ERR");
+
+            Assert.IsTrue(r.IsSuccess);
+            Assert.AreEqual(123, r.Value);
+            
+            var r2 = await Result.SuccessIf(async () =>
+            {
+                await UniTask.Delay(1);
+                return 123 < 100;
+            }, 123, "ERR");
+            
+            Assert.IsTrue(r2.IsFailure);
+            Assert.AreEqual("ERR", r2.Error);
+        }
+        
+        [Test]
+        public async Task FailureIfFactoryMethod_Async()
+        {
+            var r = await Result.FailureIf(async () =>
+            {
+                await UniTask.Delay(1);
+                return 123 < 100;
+            }, 123, "ERR");
+
+            Assert.IsTrue(r.IsSuccess);
+            Assert.AreEqual(123, r.Value);
+            
+            var r2 = await Result.FailureIf(async () =>
+            {
+                await UniTask.Delay(1);
+                return 123 > 100;
+            }, 123, "ERR");
+            
+            Assert.IsTrue(r2.IsFailure);
+            Assert.AreEqual("ERR", r2.Error);
+        }
+        
+        [Test]
+        public async Task OfFactoryMethod_Async()
+        {
+            var r = await Result.Of(async () =>
+            {
+                await UniTask.Delay(1);
+                return 123;
+            }, ex => "ERR");
+
+            Assert.IsTrue(r.IsSuccess);
+            Assert.AreEqual(123, r.Value);
+            
+            var r2 = await Result.Of(async () =>
+            {
+                await UniTask.Delay(1);
+                throw new Exception("ERR");
+                return 0;
+            }, ex => "ERR");
+
+            Assert.IsTrue(r2.IsFailure);
+            Assert.AreEqual("ERR", r2.Error);
+        }
+#endif
+    }
 
     // =======================================================
     // 2) SYNC EXTENSIONS TESTS

--- a/Packages/Unity-NOPE/Runtime/Core/Result/Result.ResultFactory.cs
+++ b/Packages/Unity-NOPE/Runtime/Core/Result/Result.ResultFactory.cs
@@ -10,29 +10,29 @@ namespace NOPE.Runtime.Core.Result
     public readonly partial struct Result
     {
         /// <summary>
-        /// Returns Success(resultValue) if condition is true; otherwise Failure(error).
+        /// Returns Success(successValue) if condition is true; otherwise Failure(error).
         /// </summary>
         public static Result<T, E> SuccessIf<T, E>(
             bool condition,
-            T resultValue,
+            T successValue,
             E error)
         {
             return condition
-                ? Result<T, E>.Success(resultValue)
+                ? Result<T, E>.Success(successValue)
                 : Result<T, E>.Failure(error);
         }
 
         /// <summary>
-        /// Returns Success(resultValue) if condition() is true; otherwise Failure(error).
+        /// Returns Success(successValue) if condition() is true; otherwise Failure(error).
         /// Lazy-evaluated predicate.
         /// </summary>
         public static Result<T, E> SuccessIf<T, E>(
             Func<bool> condition,
-            T resultValue,
+            T successValue,
             E error)
         {
             return condition()
-                ? Result<T, E>.Success(resultValue)
+                ? Result<T, E>.Success(successValue)
                 : Result<T, E>.Failure(error);
         }
 
@@ -61,7 +61,7 @@ namespace NOPE.Runtime.Core.Result
                 ? Result<T, E>.Failure(error)
                 : Result<T, E>.Success(successValue);
         }
-
+        
         /// <summary>
         /// Wraps a function call that may throw and returns:
         /// - Success(result) if no exception
@@ -81,17 +81,17 @@ namespace NOPE.Runtime.Core.Result
                 return errorConverter(ex);
             }
         }
-        
+
 #if NOPE_UNITASK
         /// <summary>
         /// Returns Success(successValue) if conditionAsync is true; otherwise Failure(error).
         /// </summary>
         public static async UniTask<Result<T, E>> SuccessIf<T, E>(
-            UniTask<bool> conditionAsync,
+            Func<UniTask<bool>> conditionAsync,
             T successValue,
             E error)
         {
-            bool cond = await conditionAsync;
+            bool cond = await conditionAsync();
             return cond
                 ? Result<T, E>.Success(successValue)
                 : Result<T, E>.Failure(error);
@@ -101,26 +101,26 @@ namespace NOPE.Runtime.Core.Result
         /// Returns Failure(error) if conditionAsync is true; otherwise Success(successValue).
         /// </summary>
         public static async UniTask<Result<T, E>> FailureIf<T, E>(
-            UniTask<bool> conditionAsync,
+            Func<UniTask<bool>> conditionAsync,
             T successValue,
             E error)
         {
-            bool cond = await conditionAsync;
+            bool cond = await conditionAsync();
             return cond
                 ? Result<T, E>.Failure(error)
                 : Result<T, E>.Success(successValue);
         }
-
+        
         /// <summary>
         /// Asynchronously wraps a function that may throw, returning Success or Failure.
         /// </summary>
         public static async UniTask<Result<T, E>> Of<T, E>(
-            UniTask<T> asyncFunc,
+            Func<UniTask<T>> asyncFunc,
             Func<Exception, E> errorConverter)
         {
             try
             {
-                T value = await asyncFunc;
+                T value = await asyncFunc();
                 return value;
             }
             catch (Exception ex)
@@ -135,11 +135,11 @@ namespace NOPE.Runtime.Core.Result
         /// Returns Success(successValue) if conditionAwaitable is true; otherwise Failure(error).
         /// </summary>
         public static async Awaitable<Result<T, E>> SuccessIf<T, E>(
-            Awaitable<bool> conditionAwaitable,
+            Func<Awaitable<bool>> conditionAwaitable,
             T successValue,
             E error)
         {
-            bool cond = await conditionAwaitable;
+            bool cond = await conditionAwaitable();
             return cond
                 ? Result<T, E>.Success(successValue)
                 : Result<T, E>.Failure(error);
@@ -149,11 +149,11 @@ namespace NOPE.Runtime.Core.Result
         /// Returns Failure(error) if conditionAwaitable is true; otherwise Success(successValue).
         /// </summary>
         public static async Awaitable<Result<T, E>> FailureIf<T, E>(
-            Awaitable<bool> conditionAwaitable,
+            Func<Awaitable<bool>> conditionAwaitable,
             T successValue,
             E error)
         {
-            bool cond = await conditionAwaitable;
+            bool cond = await conditionAwaitable();
             return cond
                 ? Result<T, E>.Failure(error)
                 : Result<T, E>.Success(successValue);
@@ -163,12 +163,12 @@ namespace NOPE.Runtime.Core.Result
         /// Asynchronously wraps a function that may throw, returning Success or Failure.
         /// </summary>
         public static async Awaitable<Result<T, E>> Of<T, E>(
-            Awaitable<T> awaitedFunc,
+            Func<Awaitable<T>> awaitedFunc,
             Func<Exception, E> errorConverter)
         {
             try
             {
-                T value = await awaitedFunc;
+                T value = await awaitedFunc();
                 return value;
             }
             catch (Exception ex)


### PR DESCRIPTION
## Bug Fix
### Result Factory Methods
- Fix wrong async function parameters.
  - `UniTask<>` -> `Func<UniTask<>>`
- Refactor parameter name of async `Result` factory methods for consistency.