### PR TITLE
Adds fallback methods for Maybe and Result types

### DIFF
--- a/Assets/Tests/MaybeTests/Maybe_OrElse_Tests.cs
+++ b/Assets/Tests/MaybeTests/Maybe_OrElse_Tests.cs
@@ -1,0 +1,489 @@
+using NOPE.Runtime.Core.Maybe;
+using NOPE.Runtime.Core.Result;
+using NUnit.Framework;
+using System;
+
+#if NOPE_UNITASK
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+#endif
+
+#if NOPE_AWAITABLE
+using UnityEngine;
+#endif
+
+namespace NOPE.Tests.MaybeTests
+{
+    [TestFixture]
+    public class Maybe_OrElse_Tests
+    {
+        #region OrElse<T> -> Maybe<T>
+
+        [Test]
+        public void OrElse_Maybe_WithValue_ReturnsOriginalMaybe()
+        {
+            var maybe = Maybe<int>.From(42);
+            var fallback = Maybe<int>.From(100);
+            
+            var result = maybe.OrElse(() => fallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public void OrElse_Maybe_WithoutValue_ReturnsFallbackMaybe()
+        {
+            var maybe = Maybe<int>.None;
+            var fallback = Maybe<int>.From(100);
+            
+            var result = maybe.OrElse(() => fallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        [Test]
+        public void OrElse_Maybe_WithoutValue_FallbackIsNone_ReturnsNone()
+        {
+            var maybe = Maybe<int>.None;
+            var fallback = Maybe<int>.None;
+            
+            var result = maybe.OrElse(() => fallback);
+            
+            Assert.IsFalse(result.HasValue);
+        }
+
+        [Test]
+        public void OrElse_Maybe_FallbackFunctionExecutedOnlyWhenNeeded()
+        {
+            var maybe = Maybe<int>.From(42);
+            var executionCount = 0;
+            
+            var result = maybe.OrElse(() => 
+            {
+                executionCount++;
+                return Maybe<int>.From(100);
+            });
+            
+            Assert.AreEqual(0, executionCount);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public void OrElse_Maybe_FallbackFunctionExecutedWhenNoValue()
+        {
+            var maybe = Maybe<int>.None;
+            var executionCount = 0;
+            
+            var result = maybe.OrElse(() => 
+            {
+                executionCount++;
+                return Maybe<int>.From(100);
+            });
+            
+            Assert.AreEqual(1, executionCount);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        #endregion
+
+        #region OrElse<T, E> -> Result<T, E>
+
+        [Test]
+        public void OrElse_Result_WithValue_ReturnsSuccessResult()
+        {
+            var maybe = Maybe<int>.From(42);
+            var error = "Error";
+            
+            var result = maybe.OrElse(() => Result<int, string>.Failure(error));
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public void OrElse_Result_WithoutValue_ReturnsFallbackResult()
+        {
+            var maybe = Maybe<int>.None;
+            var error = "Error";
+            
+            var result = maybe.OrElse(() => Result<int, string>.Failure(error));
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        [Test]
+        public void OrElse_Result_WithoutValue_FallbackIsSuccess_ReturnsSuccess()
+        {
+            var maybe = Maybe<int>.None;
+            
+            var result = maybe.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        [Test]
+        public void OrElse_Result_FallbackFunctionExecutedOnlyWhenNeeded()
+        {
+            var maybe = Maybe<int>.From(42);
+            var executionCount = 0;
+            
+            var result = maybe.OrElse(() => 
+            {
+                executionCount++;
+                return Result<int, string>.Failure("Error");
+            });
+            
+            Assert.AreEqual(0, executionCount);
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        #endregion
+
+        #region UniTask Tests
+
+#if NOPE_UNITASK
+        [Test]
+        public async Task OrElse_UniTask_Maybe_Sync_WithValue_ReturnsOriginalMaybe()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.From(42));
+            var fallback = Maybe<int>.From(100);
+            
+            var result = await asyncMaybe.OrElse(() => fallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_Maybe_Sync_WithoutValue_ReturnsFallbackMaybe()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.None);
+            var fallback = Maybe<int>.From(100);
+            
+            var result = await asyncMaybe.OrElse(() => fallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_Maybe_Async_WithValue_ReturnsOriginalMaybe()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.From(42));
+            var asyncFallback = UniTask.FromResult(Maybe<int>.From(100));
+            
+            var result = await asyncMaybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_Maybe_Async_WithoutValue_ReturnsFallbackMaybe()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.None);
+            var asyncFallback = UniTask.FromResult(Maybe<int>.From(100));
+            
+            var result = await asyncMaybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Maybe_UniTask_WithValue_ReturnsOriginalMaybe()
+        {
+            var maybe = Maybe<int>.From(42);
+            var asyncFallback = UniTask.FromResult(Maybe<int>.From(100));
+            
+            var result = await maybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Maybe_UniTask_WithoutValue_ReturnsFallbackMaybe()
+        {
+            var maybe = Maybe<int>.None;
+            var asyncFallback = UniTask.FromResult(Maybe<int>.From(100));
+            
+            var result = await maybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_Result_Sync_WithValue_ReturnsSuccessResult()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.From(42));
+            var error = "Error";
+            
+            var result = await asyncMaybe.OrElse(() => Result<int, string>.Failure(error));
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_Result_Sync_WithoutValue_ReturnsFallbackResult()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.None);
+            var error = "Error";
+            
+            var result = await asyncMaybe.OrElse(() => Result<int, string>.Failure(error));
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_Result_Async_WithValue_ReturnsSuccessResult()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.From(42));
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Failure("Error"));
+            
+            var result = await asyncMaybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_Result_Async_WithoutValue_ReturnsFallbackResult()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.None);
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Failure("Error"));
+            
+            var result = await asyncMaybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual("Error", result.Error);
+        }
+
+        [Test]
+        public async Task OrElse_Maybe_UniTask_Result_WithValue_ReturnsSuccessResult()
+        {
+            var maybe = Maybe<int>.From(42);
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Failure("Error"));
+            
+            var result = await maybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Maybe_UniTask_Result_WithoutValue_ReturnsFallbackResult()
+        {
+            var maybe = Maybe<int>.None;
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Failure("Error"));
+            
+            var result = await maybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual("Error", result.Error);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_FallbackFunctionExecutedOnlyWhenNeeded()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.From(42));
+            var executionCount = 0;
+            
+            var result = await asyncMaybe.OrElse(() => 
+            {
+                executionCount++;
+                return UniTask.FromResult(Maybe<int>.From(100));
+            });
+            
+            Assert.AreEqual(0, executionCount);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+#endif
+
+        #endregion
+
+        #region Awaitable Tests
+
+#if NOPE_AWAITABLE
+        [Test]
+        public async Task OrElse_Awaitable_Maybe_Sync_WithValue_ReturnsOriginalMaybe()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.From(42));
+            var fallback = Maybe<int>.From(100);
+            
+            var result = await asyncMaybe.OrElse(() => fallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Maybe_Sync_WithoutValue_ReturnsFallbackMaybe()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.None);
+            var fallback = Maybe<int>.From(100);
+            
+            var result = await asyncMaybe.OrElse(() => fallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Maybe_Async_WithValue_ReturnsOriginalMaybe()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.From(42));
+            var asyncFallback = AwaitableFromResult(Maybe<int>.From(100));
+            
+            var result = await asyncMaybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Maybe_Async_WithoutValue_ReturnsFallbackMaybe()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.None);
+            var asyncFallback = AwaitableFromResult(Maybe<int>.From(100));
+            
+            var result = await asyncMaybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Maybe_Awaitable_WithValue_ReturnsOriginalMaybe()
+        {
+            var maybe = Maybe<int>.From(42);
+            var asyncFallback = AwaitableFromResult(Maybe<int>.From(100));
+            
+            var result = await maybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Maybe_Awaitable_WithoutValue_ReturnsFallbackMaybe()
+        {
+            var maybe = Maybe<int>.None;
+            var asyncFallback = AwaitableFromResult(Maybe<int>.From(100));
+            
+            var result = await maybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(100, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Result_Sync_WithValue_ReturnsSuccessResult()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.From(42));
+            var error = "Error";
+            
+            var result = await asyncMaybe.OrElse(() => Result<int, string>.Failure(error));
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Result_Sync_WithoutValue_ReturnsFallbackResult()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.None);
+            var error = "Error";
+            
+            var result = await asyncMaybe.OrElse(() => Result<int, string>.Failure(error));
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Result_Async_WithValue_ReturnsSuccessResult()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.From(42));
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Failure("Error"));
+            
+            var result = await asyncMaybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Result_Async_WithoutValue_ReturnsFallbackResult()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.None);
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Failure("Error"));
+            
+            var result = await asyncMaybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual("Error", result.Error);
+        }
+
+        [Test]
+        public async Task OrElse_Maybe_Awaitable_Result_WithValue_ReturnsSuccessResult()
+        {
+            var maybe = Maybe<int>.From(42);
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Failure("Error"));
+            
+            var result = await maybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Maybe_Awaitable_Result_WithoutValue_ReturnsFallbackResult()
+        {
+            var maybe = Maybe<int>.None;
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Failure("Error"));
+            
+            var result = await maybe.OrElse(() => asyncFallback);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual("Error", result.Error);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_FallbackFunctionExecutedOnlyWhenNeeded()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.From(42));
+            var executionCount = 0;
+            
+            var result = await asyncMaybe.OrElse(() => 
+            {
+                executionCount++;
+                return AwaitableFromResult(Maybe<int>.From(100));
+            });
+            
+            Assert.AreEqual(0, executionCount);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        private async Task<T> AwaitableFromResult<T>(T value)
+        {
+            await Awaitable.NextFrameAsync();
+            return value;
+        }
+#endif
+
+        #endregion
+    }
+}

--- a/Assets/Tests/MaybeTests/Maybe_OrElse_Tests.cs.meta
+++ b/Assets/Tests/MaybeTests/Maybe_OrElse_Tests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5633243f84d65451391faf7eb6c89843

--- a/Assets/Tests/MaybeTests/Maybe_ToResult_Tests.cs
+++ b/Assets/Tests/MaybeTests/Maybe_ToResult_Tests.cs
@@ -1,0 +1,388 @@
+using NOPE.Runtime.Core.Maybe;
+using NOPE.Runtime.Core.Result;
+using NUnit.Framework;
+using System;
+
+#if NOPE_UNITASK
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+#endif
+
+#if NOPE_AWAITABLE
+using UnityEngine;
+#endif
+
+namespace NOPE.Tests.MaybeTests
+{
+    [TestFixture]
+    public class Maybe_ToResult_Tests
+    {
+        #region Basic ToResult Tests
+
+        [Test]
+        public void ToResult_WithValue_ReturnsSuccessResult()
+        {
+            var maybe = Maybe<int>.From(42);
+            var error = "No value";
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public void ToResult_WithoutValue_ReturnsFailureResult()
+        {
+            var maybe = Maybe<int>.None;
+            var error = "No value";
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        [Test]
+        public void ToResult_WithValue_DifferentTypes()
+        {
+            var maybe = Maybe<string>.From("Hello");
+            var error = 404;
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual("Hello", result.Value);
+        }
+
+        [Test]
+        public void ToResult_WithoutValue_DifferentTypes()
+        {
+            var maybe = Maybe<string>.None;
+            var error = 404;
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(404, result.Error);
+        }
+
+        [Test]
+        public void ToResult_WithValue_ComplexErrorType()
+        {
+            var maybe = Maybe<int>.From(42);
+            var error = new Exception("No value");
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public void ToResult_WithoutValue_ComplexErrorType()
+        {
+            var maybe = Maybe<int>.None;
+            var error = new Exception("No value");
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+            Assert.AreEqual("No value", result.Error.Message);
+        }
+
+        [Test]
+        public void ToResult_WithValue_NullableValueType()
+        {
+            var maybe = Maybe<int?>.From(42);
+            var error = "No value";
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public void ToResult_WithValue_NullableValueTypeWithNull()
+        {
+            var maybe = Maybe<int?>.From(null);
+            var error = "No value";
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        [Test]
+        public void ToResult_WithoutValue_NullableValueType()
+        {
+            var maybe = Maybe<int?>.None;
+            var error = "No value";
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        [Test]
+        public void ToResult_WithValue_ReferenceType()
+        {
+            var obj = new TestClass { Value = 42 };
+            var maybe = Maybe<TestClass>.From(obj);
+            var error = "No value";
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreSame(obj, result.Value);
+            Assert.AreEqual(42, result.Value.Value);
+        }
+
+        [Test]
+        public void ToResult_WithoutValue_ReferenceType()
+        {
+            var maybe = Maybe<TestClass>.None;
+            var error = "No value";
+            
+            var result = maybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        #endregion
+
+        #region UniTask Tests
+
+#if NOPE_UNITASK
+        [Test]
+        public async Task ToResult_UniTask_WithValue_ReturnsSuccessResult()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.From(42));
+            var error = "No value";
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task ToResult_UniTask_WithoutValue_ReturnsFailureResult()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.None);
+            var error = "No value";
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        [Test]
+        public async Task ToResult_UniTask_WithValue_DifferentTypes()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<string>.From("Hello"));
+            var error = 404;
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual("Hello", result.Value);
+        }
+
+        [Test]
+        public async Task ToResult_UniTask_WithoutValue_DifferentTypes()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<string>.None);
+            var error = 404;
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(404, result.Error);
+        }
+
+        [Test]
+        public async Task ToResult_UniTask_WithValue_ComplexErrorType()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.From(42));
+            var error = new Exception("No value");
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task ToResult_UniTask_WithoutValue_ComplexErrorType()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.None);
+            var error = new Exception("No value");
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+            Assert.AreEqual("No value", result.Error.Message);
+        }
+
+        [Test]
+        public async Task ToResult_UniTask_ChainedOperations()
+        {
+            var asyncMaybe = UniTask.FromResult(Maybe<int>.From(42));
+            
+            var result = await asyncMaybe
+                .ToResult("Initial error");
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task ToResult_UniTask_DelayedExecution()
+        {
+            var asyncMaybe = UniTask.Create(async () =>
+            {
+                await UniTask.Delay(10);
+                return Maybe<int>.From(42);
+            });
+            
+            var result = await asyncMaybe.ToResult("No value");
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+#endif
+
+        #endregion
+
+        #region Awaitable Tests
+
+#if NOPE_AWAITABLE
+        [Test]
+        public async Task ToResult_Awaitable_WithValue_ReturnsSuccessResult()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.From(42));
+            var error = "No value";
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task ToResult_Awaitable_WithoutValue_ReturnsFailureResult()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.None);
+            var error = "No value";
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+        }
+
+        [Test]
+        public async Task ToResult_Awaitable_WithValue_DifferentTypes()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<string>.From("Hello"));
+            var error = 404;
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual("Hello", result.Value);
+        }
+
+        [Test]
+        public async Task ToResult_Awaitable_WithoutValue_DifferentTypes()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<string>.None);
+            var error = 404;
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(404, result.Error);
+        }
+
+        [Test]
+        public async Task ToResult_Awaitable_WithValue_ComplexErrorType()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.From(42));
+            var error = new Exception("No value");
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task ToResult_Awaitable_WithoutValue_ComplexErrorType()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.None);
+            var error = new Exception("No value");
+            
+            var result = await asyncMaybe.ToResult(error);
+            
+            Assert.IsTrue(result.IsFailure);
+            Assert.AreEqual(error, result.Error);
+            Assert.AreEqual("No value", result.Error.Message);
+        }
+
+        [Test]
+        public async Task ToResult_Awaitable_ChainedOperations()
+        {
+            var asyncMaybe = AwaitableFromResult(Maybe<int>.From(42));
+            
+            var result = await asyncMaybe
+                .ToResult("Initial error");
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        [Test]
+        public async Task ToResult_Awaitable_DelayedExecution()
+        {
+            var asyncMaybe = DelayedAwaitableFromResult(Maybe<int>.From(42));
+            
+            var result = await asyncMaybe.ToResult("No value");
+            
+            Assert.IsTrue(result.IsSuccess);
+            Assert.AreEqual(42, result.Value);
+        }
+
+        private async Task<T> AwaitableFromResult<T>(T value)
+        {
+            await Awaitable.NextFrameAsync();
+            return value;
+        }
+
+        private async Task<T> DelayedAwaitableFromResult<T>(T value)
+        {
+            await Awaitable.WaitForSecondsAsync(0.01f);
+            return value;
+        }
+#endif
+
+        #endregion
+
+        #region Helper Classes
+
+        private class TestClass
+        {
+            public int Value { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Tests/MaybeTests/Maybe_ToResult_Tests.cs.meta
+++ b/Assets/Tests/MaybeTests/Maybe_ToResult_Tests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ead48d8401aa24f8da4b89ffd25a5c2a

--- a/Assets/Tests/PerformanceBenchmarks/CSharpFunctionalExtensionsPerformanceTests.cs
+++ b/Assets/Tests/PerformanceBenchmarks/CSharpFunctionalExtensionsPerformanceTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using NUnit.Framework;
 using Unity.PerformanceTesting;
@@ -17,7 +18,7 @@ namespace NOPE.Tests.PerformanceBenchmarks
         }
 
         [Test, Performance]
-        public void SyncComposite_CFE()
+        public async Task SyncComposite_CFE()
         {
             Measure.Method(() =>
                 {

--- a/Assets/Tests/ResultTests/Result_OrElse_Tests.cs
+++ b/Assets/Tests/ResultTests/Result_OrElse_Tests.cs
@@ -1,0 +1,475 @@
+using NOPE.Runtime.Core.Result;
+using NUnit.Framework;
+using System;
+
+#if NOPE_UNITASK
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+#endif
+
+#if NOPE_AWAITABLE
+using UnityEngine;
+#endif
+
+namespace NOPE.Tests.ResultTests
+{
+    [TestFixture]
+    public class Result_OrElse_Tests
+    {
+        #region Basic OrElse Tests
+
+        [Test]
+        public void OrElse_Success_ReturnsOriginalResult()
+        {
+            var result = Result<int, string>.Success(42);
+            
+            var final = result.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public void OrElse_Failure_CallsFallbackFunction()
+        {
+            var result = Result<int, string>.Failure("Error");
+            
+            var final = result.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public void OrElse_Failure_FallbackAlsoFailure_ReturnsFallbackFailure()
+        {
+            var result = Result<int, string>.Failure("First Error");
+            
+            var final = result.OrElse(() => Result<int, string>.Failure("Second Error"));
+            
+            Assert.IsTrue(final.IsFailure);
+            Assert.AreEqual("Second Error", final.Error);
+        }
+
+        [Test]
+        public void OrElse_Success_FallbackNotExecuted()
+        {
+            var result = Result<int, string>.Success(42);
+            var fallbackExecuted = false;
+            
+            var final = result.OrElse(() =>
+            {
+                fallbackExecuted = true;
+                return Result<int, string>.Success(100);
+            });
+            
+            Assert.IsFalse(fallbackExecuted);
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public void OrElse_Failure_FallbackExecuted()
+        {
+            var result = Result<int, string>.Failure("Error");
+            var fallbackExecuted = false;
+            
+            var final = result.OrElse(() =>
+            {
+                fallbackExecuted = true;
+                return Result<int, string>.Success(100);
+            });
+            
+            Assert.IsTrue(fallbackExecuted);
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public void OrElse_ComplexTypes_Success()
+        {
+            var result = Result<TestClass, Exception>.Success(new TestClass { Value = 42 });
+            
+            var final = result.OrElse(() => Result<TestClass, Exception>.Success(new TestClass { Value = 100 }));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value.Value);
+        }
+
+        [Test]
+        public void OrElse_ComplexTypes_Failure()
+        {
+            var result = Result<TestClass, Exception>.Failure(new Exception("First"));
+            
+            var final = result.OrElse(() => Result<TestClass, Exception>.Success(new TestClass { Value = 100 }));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value.Value);
+        }
+
+        [Test]
+        public void OrElse_ChainedOperations()
+        {
+            var result = Result<int, string>.Failure("Error1");
+            
+            var final = result
+                .OrElse(() => Result<int, string>.Failure("Error2"))
+                .OrElse(() => Result<int, string>.Success(42));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public void OrElse_FallbackBasedOnError()
+        {
+            var result = Result<int, string>.Failure("NotFound");
+            
+            var final = result.OrElse(() =>
+            {
+                if (result.Error == "NotFound")
+                    return Result<int, string>.Success(0);
+                return Result<int, string>.Failure("Unknown Error");
+            });
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(0, final.Value);
+        }
+
+        [Test]
+        public void OrElse_MultipleFallbacks_ExecutionCount()
+        {
+            var result = Result<int, string>.Failure("Error");
+            var executionCount = 0;
+            
+            var final = result
+                .OrElse(() =>
+                {
+                    executionCount++;
+                    return Result<int, string>.Failure("Error2");
+                })
+                .OrElse(() =>
+                {
+                    executionCount++;
+                    return Result<int, string>.Success(42);
+                });
+            
+            Assert.AreEqual(2, executionCount);
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        #endregion
+
+        #region UniTask Tests
+
+#if NOPE_UNITASK
+        [Test]
+        public async Task OrElse_UniTask_Sync_Success_ReturnsOriginalResult()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Success(42));
+            
+            var final = await asyncResult.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_Sync_Failure_CallsFallbackFunction()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Failure("Error"));
+            
+            var final = await asyncResult.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Sync_UniTask_Success_ReturnsOriginalResult()
+        {
+            var result = Result<int, string>.Success(42);
+            
+            var final = await result.OrElse(() => UniTask.FromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Sync_UniTask_Failure_CallsFallbackFunction()
+        {
+            var result = Result<int, string>.Failure("Error");
+            
+            var final = await result.OrElse(() => UniTask.FromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_UniTask_Success_ReturnsOriginalResult()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Success(42));
+            
+            var final = await asyncResult.OrElse(() => UniTask.FromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_UniTask_Failure_CallsFallbackFunction()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Failure("Error"));
+            
+            var final = await asyncResult.OrElse(() => UniTask.FromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_FallbackNotExecutedWhenSuccess()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Success(42));
+            var fallbackExecuted = false;
+            
+            var final = await asyncResult.OrElse(() =>
+            {
+                fallbackExecuted = true;
+                return UniTask.FromResult(Result<int, string>.Success(100));
+            });
+            
+            Assert.IsFalse(fallbackExecuted);
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Sync_UniTask_FallbackNotExecutedWhenSuccess()
+        {
+            var result = Result<int, string>.Success(42);
+            var fallbackExecuted = false;
+            
+            var final = await result.OrElse(() =>
+            {
+                fallbackExecuted = true;
+                return UniTask.FromResult(Result<int, string>.Success(100));
+            });
+            
+            Assert.IsFalse(fallbackExecuted);
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_ChainedOperations()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Failure("Error1"));
+            
+            var final = await asyncResult
+                .OrElse(() => Result<int, string>.Failure("Error2"))
+                .OrElse(() => UniTask.FromResult(Result<int, string>.Success(42)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_DelayedExecution()
+        {
+            var asyncResult = UniTask.Run(async () =>
+            {
+                await UniTask.Delay(10);
+                return Result<int, string>.Failure("Error");
+            });
+            
+            var final = await asyncResult.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_UniTask_AsyncFallbackDelayed()
+        {
+            var result = Result<int, string>.Failure("Error");
+            
+            var final = await result.OrElse(() => UniTask.Run(async () =>
+            {
+                await UniTask.Delay(10);
+                return Result<int, string>.Success(100);
+            }));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+#endif
+
+        #endregion
+
+        #region Awaitable Tests
+
+#if NOPE_AWAITABLE
+        [Test]
+        public async Task OrElse_Awaitable_Sync_Success_ReturnsOriginalResult()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Success(42));
+            
+            var final = await asyncResult.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Sync_Failure_CallsFallbackFunction()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Failure("Error"));
+            
+            var final = await asyncResult.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Sync_Awaitable_Success_ReturnsOriginalResult()
+        {
+            var result = Result<int, string>.Success(42);
+            
+            var final = await result.OrElse(() => AwaitableFromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Sync_Awaitable_Failure_CallsFallbackFunction()
+        {
+            var result = Result<int, string>.Failure("Error");
+            
+            var final = await result.OrElse(() => AwaitableFromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Awaitable_Success_ReturnsOriginalResult()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Success(42));
+            
+            var final = await asyncResult.OrElse(() => AwaitableFromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_Awaitable_Failure_CallsFallbackFunction()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Failure("Error"));
+            
+            var final = await asyncResult.OrElse(() => AwaitableFromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_FallbackNotExecutedWhenSuccess()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Success(42));
+            var fallbackExecuted = false;
+            
+            var final = await asyncResult.OrElse(() =>
+            {
+                fallbackExecuted = true;
+                return AwaitableFromResult(Result<int, string>.Success(100));
+            });
+            
+            Assert.IsFalse(fallbackExecuted);
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Sync_Awaitable_FallbackNotExecutedWhenSuccess()
+        {
+            var result = Result<int, string>.Success(42);
+            var fallbackExecuted = false;
+            
+            var final = await result.OrElse(() =>
+            {
+                fallbackExecuted = true;
+                return AwaitableFromResult(Result<int, string>.Success(100));
+            });
+            
+            Assert.IsFalse(fallbackExecuted);
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_ChainedOperations()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Failure("Error1"));
+            
+            var final = await (await asyncResult
+                .OrElse(() => Result<int, string>.Failure("Error2")))
+                .OrElse(() => AwaitableFromResult(Result<int, string>.Success(42)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_DelayedExecution()
+        {
+            var asyncResult = DelayedAwaitableFromResult(Result<int, string>.Failure("Error"));
+            
+            var final = await asyncResult.OrElse(() => Result<int, string>.Success(100));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task OrElse_Awaitable_AsyncFallbackDelayed()
+        {
+            var result = Result<int, string>.Failure("Error");
+            
+            var final = await result.OrElse(() => DelayedAwaitableFromResult(Result<int, string>.Success(100)));
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        private async Awaitable<T> AwaitableFromResult<T>(T value)
+        {
+            await Awaitable.NextFrameAsync();
+            return value;
+        }
+
+        private async Awaitable<T> DelayedAwaitableFromResult<T>(T value)
+        {
+            await Awaitable.WaitForSecondsAsync(0.01f);
+            return value;
+        }
+#endif
+
+        #endregion
+
+        #region Helper Classes
+
+        private class TestClass
+        {
+            public int Value { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Tests/ResultTests/Result_OrElse_Tests.cs.meta
+++ b/Assets/Tests/ResultTests/Result_OrElse_Tests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 375c4564c3d854bde911646f0f564e2e

--- a/Assets/Tests/ResultTests/Result_Or_Tests.cs
+++ b/Assets/Tests/ResultTests/Result_Or_Tests.cs
@@ -1,0 +1,405 @@
+using NOPE.Runtime.Core.Result;
+using NUnit.Framework;
+using System;
+
+#if NOPE_UNITASK
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+#endif
+
+#if NOPE_AWAITABLE
+using UnityEngine;
+#endif
+
+namespace NOPE.Tests.ResultTests
+{
+    [TestFixture]
+    public class Result_Or_Tests
+    {
+        #region Basic Or Tests
+
+        [Test]
+        public void Or_Success_ReturnsOriginalResult()
+        {
+            var result = Result<int, string>.Success(42);
+            var fallback = Result<int, string>.Success(100);
+            
+            var final = result.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public void Or_Failure_ReturnsFallbackResult()
+        {
+            var result = Result<int, string>.Failure("Error");
+            var fallback = Result<int, string>.Success(100);
+            
+            var final = result.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public void Or_Failure_FallbackAlsoFailure_ReturnsFallbackFailure()
+        {
+            var result = Result<int, string>.Failure("First Error");
+            var fallback = Result<int, string>.Failure("Second Error");
+            
+            var final = result.Or(fallback);
+            
+            Assert.IsTrue(final.IsFailure);
+            Assert.AreEqual("Second Error", final.Error);
+        }
+
+        [Test]
+        public void Or_Success_FallbackIsFailure_ReturnsOriginalSuccess()
+        {
+            var result = Result<int, string>.Success(42);
+            var fallback = Result<int, string>.Failure("Error");
+            
+            var final = result.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public void Or_ComplexTypes_Success()
+        {
+            var result = Result<TestClass, Exception>.Success(new TestClass { Value = 42 });
+            var fallback = Result<TestClass, Exception>.Success(new TestClass { Value = 100 });
+            
+            var final = result.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value.Value);
+        }
+
+        [Test]
+        public void Or_ComplexTypes_Failure()
+        {
+            var result = Result<TestClass, Exception>.Failure(new Exception("First"));
+            var fallback = Result<TestClass, Exception>.Success(new TestClass { Value = 100 });
+            
+            var final = result.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value.Value);
+        }
+
+        [Test]
+        public void Or_ChainedOperations()
+        {
+            var result = Result<int, string>.Failure("Error1");
+            var fallback1 = Result<int, string>.Failure("Error2");
+            var fallback2 = Result<int, string>.Success(42);
+            
+            var final = result.Or(fallback1).Or(fallback2);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        #endregion
+
+        #region UniTask Tests
+
+#if NOPE_UNITASK
+        [Test]
+        public async Task Or_UniTask_Sync_Success_ReturnsOriginalResult()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Success(42));
+            var fallback = Result<int, string>.Success(100);
+            
+            var final = await asyncResult.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task Or_UniTask_Sync_Failure_ReturnsFallbackResult()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Failure("Error"));
+            var fallback = Result<int, string>.Success(100);
+            
+            var final = await asyncResult.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Sync_UniTask_Success_ReturnsOriginalResult()
+        {
+            var result = Result<int, string>.Success(42);
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Success(100));
+            
+            var final = await result.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Sync_UniTask_Failure_ReturnsFallbackResult()
+        {
+            var result = Result<int, string>.Failure("Error");
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Success(100));
+            
+            var final = await result.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task Or_UniTask_UniTask_Success_ReturnsOriginalResult()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Success(42));
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Success(100));
+            
+            var final = await asyncResult.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task Or_UniTask_UniTask_Failure_ReturnsFallbackResult()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Failure("Error"));
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Success(100));
+            
+            var final = await asyncResult.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task Or_UniTask_BothFailure_ReturnsFallbackFailure()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Failure("First Error"));
+            var asyncFallback = UniTask.FromResult(Result<int, string>.Failure("Second Error"));
+            
+            var final = await asyncResult.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsFailure);
+            Assert.AreEqual("Second Error", final.Error);
+        }
+
+        [Test]
+        public async Task Or_UniTask_FallbackNotEvaluatedWhenSuccess()
+        {
+            var result = Result<int, string>.Success(42);
+            var evaluatedFallback = false;
+            var asyncFallback = UniTask.Run(() =>
+            {
+                evaluatedFallback = true;
+                return Result<int, string>.Success(100);
+            });
+            
+            var final = await result.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+            Assert.IsFalse(evaluatedFallback);
+        }
+
+        [Test]
+        public async Task Or_UniTask_ChainedOperations()
+        {
+            var asyncResult = UniTask.FromResult(Result<int, string>.Failure("Error1"));
+            var asyncFallback1 = UniTask.FromResult(Result<int, string>.Failure("Error2"));
+            var fallback2 = Result<int, string>.Success(42);
+            
+            var final =  (await asyncResult.Or(asyncFallback1)).Or(fallback2);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task Or_UniTask_DelayedExecution()
+        {
+            var asyncResult = UniTask.Run(async () =>
+            {
+                await UniTask.Delay(10);
+                return Result<int, string>.Failure("Error");
+            });
+            var fallback = Result<int, string>.Success(100);
+            
+            var final = await asyncResult.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+#endif
+
+        #endregion
+
+        #region Awaitable Tests
+
+#if NOPE_AWAITABLE
+        [Test]
+        public async Task Or_Awaitable_Sync_Success_ReturnsOriginalResult()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Success(42));
+            var fallback = Result<int, string>.Success(100);
+            
+            var final = await asyncResult.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Awaitable_Sync_Failure_ReturnsFallbackResult()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Failure("Error"));
+            var fallback = Result<int, string>.Success(100);
+            
+            var final = await asyncResult.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Sync_Awaitable_Success_ReturnsOriginalResult()
+        {
+            var result = Result<int, string>.Success(42);
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Success(100));
+            
+            var final = await result.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Sync_Awaitable_Failure_ReturnsFallbackResult()
+        {
+            var result = Result<int, string>.Failure("Error");
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Success(100));
+            
+            var final = await result.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Awaitable_Awaitable_Success_ReturnsOriginalResult()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Success(42));
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Success(100));
+            
+            var final = await asyncResult.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Awaitable_Awaitable_Failure_ReturnsFallbackResult()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Failure("Error"));
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Success(100));
+            
+            var final = await asyncResult.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Awaitable_BothFailure_ReturnsFallbackFailure()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Failure("First Error"));
+            var asyncFallback = AwaitableFromResult(Result<int, string>.Failure("Second Error"));
+            
+            var final = await asyncResult.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsFailure);
+            Assert.AreEqual("Second Error", final.Error);
+        }
+
+        [Test]
+        public async Task Or_Awaitable_FallbackNotEvaluatedWhenSuccess()
+        {
+            var result = Result<int, string>.Success(42);
+            var evaluatedFallback = false;
+            var asyncFallback = EvaluatingAwaitableFromResult(() =>
+            {
+                evaluatedFallback = true;
+                return Result<int, string>.Success(100);
+            });
+            
+            var final = await result.Or(asyncFallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+            Assert.IsFalse(evaluatedFallback);
+        }
+
+        [Test]
+        public async Task Or_Awaitable_ChainedOperations()
+        {
+            var asyncResult = AwaitableFromResult(Result<int, string>.Failure("Error1"));
+            var asyncFallback1 = AwaitableFromResult(Result<int, string>.Failure("Error2"));
+            var fallback2 = Result<int, string>.Success(42);
+            
+            var final = await (await asyncResult.Or(asyncFallback1)).Or(fallback2);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(42, final.Value);
+        }
+
+        [Test]
+        public async Task Or_Awaitable_DelayedExecution()
+        {
+            var asyncResult = DelayedAwaitableFromResult(Result<int, string>.Failure("Error"));
+            var fallback = Result<int, string>.Success(100);
+            
+            var final = await asyncResult.Or(fallback);
+            
+            Assert.IsTrue(final.IsSuccess);
+            Assert.AreEqual(100, final.Value);
+        }
+
+        private async Task<T> AwaitableFromResult<T>(T value)
+        {
+            await Awaitable.NextFrameAsync();
+            return value;
+        }
+
+        private async Task<T> DelayedAwaitableFromResult<T>(T value)
+        {
+            await Awaitable.WaitForSecondsAsync(0.01f);
+            return value;
+        }
+
+        private async Task<T> EvaluatingAwaitableFromResult<T>(Func<T> valueFactory)
+        {
+            await Awaitable.NextFrameAsync();
+            return valueFactory();
+        }
+#endif
+
+        #endregion
+
+        #region Helper Classes
+
+        private class TestClass
+        {
+            public int Value { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Tests/ResultTests/Result_Or_Tests.cs.meta
+++ b/Assets/Tests/ResultTests/Result_Or_Tests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9cb88c70cc0b843d1952cedcd4e3e897

--- a/Packages/Unity-NOPE/Runtime/Core/Maybe/MaybeExtensions.OrElse.cs
+++ b/Packages/Unity-NOPE/Runtime/Core/Maybe/MaybeExtensions.OrElse.cs
@@ -1,0 +1,173 @@
+using System;
+using NOPE.Runtime.Core.Result;
+using UnityEngine;
+
+#if NOPE_UNITASK
+using Cysharp.Threading.Tasks;
+#endif
+
+namespace NOPE.Runtime.Core.Maybe
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        /// If the Maybe has a value, returns it; otherwise executes the fallback function and returns its result.
+        /// </summary>
+        public static Maybe<T> OrElse<T>(
+            this Maybe<T> maybe,
+            Func<Maybe<T>> fallbackFunc)
+        {
+            return maybe.HasValue ? maybe : fallbackFunc();
+        }
+
+        /// <summary>
+        /// If the Maybe has a value, returns it as a Result.Success; otherwise executes the fallback function and returns its result.
+        /// </summary>
+        public static Result<T, E> OrElse<T, E>(
+            this Maybe<T> maybe,
+            Func<Result<T, E>> fallbackFunc)
+        {
+            return maybe.HasValue
+                ? Result<T, E>.Success(maybe.Value)
+                : fallbackFunc();
+        }
+
+#if NOPE_UNITASK
+        // --- UniTask-based Async Methods (OrElse) ---
+
+        /// <summary>
+        /// Asynchronously returns the maybe if it has a value, otherwise executes the synchronous fallback function.
+        /// </summary>
+        public static async UniTask<Maybe<T>> OrElse<T>(
+            this UniTask<Maybe<T>> asyncMaybe,
+            Func<Maybe<T>> fallbackFunc)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.OrElse(fallbackFunc);
+        }
+
+        /// <summary>
+        /// Asynchronously returns the maybe if it has a value, otherwise executes the asynchronous fallback function.
+        /// </summary>
+        public static async UniTask<Maybe<T>> OrElse<T>(
+            this UniTask<Maybe<T>> asyncMaybe,
+            Func<UniTask<Maybe<T>>> asyncFallbackFunc)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.HasValue ? maybe : await asyncFallbackFunc();
+        }
+        
+        /// <summary>
+        /// Returns the maybe if it has a value, otherwise executes the asynchronous fallback function.
+        /// </summary>
+        public static UniTask<Maybe<T>> OrElse<T>(
+            this Maybe<T> maybe,
+            Func<UniTask<Maybe<T>>> asyncFallbackFunc)
+        {
+            return maybe.HasValue ? UniTask.FromResult(maybe) : asyncFallbackFunc();
+        }
+
+        /// <summary>
+        /// Asynchronously converts the maybe to a Result, or executes the synchronous fallback function if it has no value.
+        /// </summary>
+        public static async UniTask<Result<T, E>> OrElse<T, E>(
+            this UniTask<Maybe<T>> asyncMaybe,
+            Func<Result<T, E>> fallbackFunc)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.OrElse(fallbackFunc);
+        }
+
+        /// <summary>
+        /// Asynchronously converts the maybe to a Result, or executes the asynchronous fallback function if it has no value.
+        /// </summary>
+        public static async UniTask<Result<T, E>> OrElse<T, E>(
+            this UniTask<Maybe<T>> asyncMaybe,
+            Func<UniTask<Result<T, E>>> asyncFallbackFunc)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.HasValue ? Result<T, E>.Success(maybe.Value) : await asyncFallbackFunc();
+        }
+        
+        /// <summary>
+        /// Converts the maybe to a Result, or executes the asynchronous fallback function if it has no value.
+        /// </summary>
+        public static UniTask<Result<T, E>> OrElse<T, E>(
+            this Maybe<T> maybe,
+            Func<UniTask<Result<T, E>>> asyncFallbackFunc)
+        {
+            return maybe.HasValue ? UniTask.FromResult(Result<T, E>.Success(maybe.Value)) : asyncFallbackFunc();
+        }
+#endif
+
+#if NOPE_AWAITABLE
+        // --- Awaitable-based Async Methods (OrElse) ---
+
+        /// <summary>
+        /// Asynchronously returns the maybe if it has a value, otherwise executes the synchronous fallback function.
+        /// </summary>
+        public static async Awaitable<Maybe<T>> OrElse<T>(
+            this Awaitable<Maybe<T>> asyncMaybe,
+            Func<Maybe<T>> fallbackFunc)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.OrElse(fallbackFunc);
+        }
+
+        /// <summary>
+        /// Asynchronously returns the maybe if it has a value, otherwise executes the asynchronous fallback function.
+        /// </summary>
+        public static async Awaitable<Maybe<T>> OrElse<T>(
+            this Awaitable<Maybe<T>> asyncMaybe,
+            Func<Awaitable<Maybe<T>>> asyncFallbackFunc)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.HasValue ? maybe : await asyncFallbackFunc();
+        }
+        
+        /// <summary>
+        /// Returns the maybe if it has a value, otherwise executes the asynchronous fallback function.
+        /// </summary>
+        public static async Awaitable<Maybe<T>> OrElse<T>(
+            this Maybe<T> maybe,
+            Func<Awaitable<Maybe<T>>> asyncFallbackFunc)
+        {
+            if (maybe.HasValue) return maybe;
+            return await asyncFallbackFunc();
+        }
+
+        /// <summary>
+        /// Asynchronously converts the maybe to a Result, or executes the synchronous fallback function if it has no value.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> OrElse<T, E>(
+            this Awaitable<Maybe<T>> asyncMaybe,
+            Func<Result<T, E>> fallbackFunc)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.OrElse(fallbackFunc);
+        }
+
+        /// <summary>
+        /// Asynchronously converts the maybe to a Result, or executes the asynchronous fallback function if it has no value.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> OrElse<T, E>(
+            this Awaitable<Maybe<T>> asyncMaybe,
+            Func<Awaitable<Result<T, E>>> asyncFallbackFunc)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.HasValue ? Result<T, E>.Success(maybe.Value) : await asyncFallbackFunc();
+        }
+        
+        /// <summary>
+        /// Converts the maybe to a Result, or executes the asynchronous fallback function if it has no value.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> OrElse<T, E>(
+            this Maybe<T> maybe,
+            Func<Awaitable<Result<T, E>>> asyncFallbackFunc)
+        {
+            if (maybe.HasValue) return Result<T, E>.Success(maybe.Value);
+            return await asyncFallbackFunc();
+        }
+#endif
+    }
+}

--- a/Packages/Unity-NOPE/Runtime/Core/Maybe/MaybeExtensions.OrElse.cs.meta
+++ b/Packages/Unity-NOPE/Runtime/Core/Maybe/MaybeExtensions.OrElse.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 37829a7a6f4434fc9b01d961eaae89dc

--- a/Packages/Unity-NOPE/Runtime/Core/Maybe/MaybeExtensions.ToResult.cs
+++ b/Packages/Unity-NOPE/Runtime/Core/Maybe/MaybeExtensions.ToResult.cs
@@ -1,0 +1,52 @@
+using NOPE.Runtime.Core.Result;
+using UnityEngine;
+#if NOPE_UNITASK
+using Cysharp.Threading.Tasks;
+#endif
+
+namespace NOPE.Runtime.Core.Maybe
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        /// Converts this Maybe to a Result, returning Success if it has a value,
+        /// or Failure with the provided error if it does not.
+        /// </summary>
+        public static Result<T, E> ToResult<T, E>(
+            this Maybe<T> maybe,
+            E error)
+        {
+            return maybe.HasValue
+                ? Result<T, E>.Success(maybe.Value)
+                : Result<T, E>.Failure(error);
+        }
+
+#if NOPE_UNITASK
+        /// <summary>
+        /// Converts an asynchronous Maybe (UniTask<Maybe<T>>) to a Result.
+        /// It awaits the Maybe and then converts it to a Result.
+        /// </summary>
+        public static async UniTask<Result<T, E>> ToResult<T, E>(
+            this UniTask<Maybe<T>> asyncMaybe,
+            E error)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.ToResult(error);
+        }
+#endif
+
+#if NOPE_AWAITABLE
+        /// <summary>
+        /// Converts an asynchronous Maybe (Awaitable<Maybe<T>>) to a Result.
+        /// It awaits the Maybe and then converts it to a Result.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> ToResult<T, E>(
+            this Awaitable<Maybe<T>> asyncMaybe,
+            E error)
+        {
+            var maybe = await asyncMaybe;
+            return maybe.ToResult(error);
+        }
+#endif
+    }
+}

--- a/Packages/Unity-NOPE/Runtime/Core/Maybe/MaybeExtensions.ToResult.cs.meta
+++ b/Packages/Unity-NOPE/Runtime/Core/Maybe/MaybeExtensions.ToResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f49f9f621fe54d50933b00877d4d50c

--- a/Packages/Unity-NOPE/Runtime/Core/Result/ResultExtensions.Or.cs
+++ b/Packages/Unity-NOPE/Runtime/Core/Result/ResultExtensions.Or.cs
@@ -1,0 +1,94 @@
+using System;
+using UnityEngine;
+
+#if NOPE_UNITASK
+using Cysharp.Threading.Tasks;
+#endif
+
+namespace NOPE.Runtime.Core.Result
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise returns the provided `fallbackResult`.
+        /// </summary>
+        public static Result<T, E> Or<T, E>(
+            this Result<T, E> result,
+            Result<T, E> fallbackResult)
+        {
+            return result.IsSuccess ? result : fallbackResult;
+        }
+
+#if NOPE_UNITASK
+        // --- UniTask --
+        
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise returns the provided `fallbackResult`.
+        /// </summary>
+        public static async UniTask<Result<T, E>> Or<T, E>(
+            this UniTask<Result<T, E>> asyncResult,
+            Result<T, E> fallbackResult)
+        {
+            var result = await asyncResult;
+            return result.Or(fallbackResult);
+        }
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise returns the provided `fallbackResult`.
+        /// </summary>
+        public static async UniTask<Result<T, E>> Or<T, E>(
+            this Result<T, E> result,
+            UniTask<Result<T, E>> asyncFallbackResult)
+        {
+            return result.IsSuccess ? result : await asyncFallbackResult;
+        }
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise returns the provided `fallbackResult`.
+        /// </summary>
+        public static async UniTask<Result<T, E>> Or<T, E>(
+            this UniTask<Result<T, E>> asyncResult,
+            UniTask<Result<T, E>> asyncFallbackResult)
+        {
+            var result = await asyncResult;
+            return result.IsSuccess ? result : await asyncFallbackResult;
+        }
+#endif
+
+#if NOPE_AWAITABLE
+        // --- Awaitable ---
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise returns the provided `fallbackResult`.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> Or<T, E>(
+            this Awaitable<Result<T, E>> asyncResult,
+            Result<T, E> fallbackResult)
+        {
+            var result = await asyncResult;
+            return result.Or(fallbackResult);
+        }
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise returns the provided `fallbackResult`.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> Or<T, E>(
+            this Result<T, E> result,
+            Awaitable<Result<T, E>> asyncFallbackResult)
+        {
+            return result.IsSuccess ? result : await asyncFallbackResult;
+        }
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise returns the provided `fallbackResult`.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> Or<T, E>(
+            this Awaitable<Result<T, E>> asyncResult,
+            Awaitable<Result<T, E>> asyncFallbackResult)
+        {
+            var result = await asyncResult;
+            return result.IsSuccess ? result : await asyncFallbackResult;
+        }
+#endif
+    }
+}

--- a/Packages/Unity-NOPE/Runtime/Core/Result/ResultExtensions.Or.cs.meta
+++ b/Packages/Unity-NOPE/Runtime/Core/Result/ResultExtensions.Or.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d3f75a4a736a4668ae883f639441a30

--- a/Packages/Unity-NOPE/Runtime/Core/Result/ResultExtensions.OrElse.cs
+++ b/Packages/Unity-NOPE/Runtime/Core/Result/ResultExtensions.OrElse.cs
@@ -1,0 +1,96 @@
+using System;
+using UnityEngine;
+
+#if NOPE_UNITASK
+using Cysharp.Threading.Tasks;
+#endif
+
+namespace NOPE.Runtime.Core.Result
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise calls the `fallbackFunc` and returns its result.
+        /// </summary>
+        public static Result<T, E> OrElse<T, E>(
+            this Result<T, E> result,
+            Func<Result<T, E>> fallbackFunc)
+        {
+            return result.IsSuccess ? result : fallbackFunc();
+        }
+
+#if NOPE_UNITASK
+        // --- UniTask-based Async Methods (OrElse) ---
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise calls the `fallbackFunc` and returns its result.
+        /// </summary>
+        public static async UniTask<Result<T, E>> OrElse<T, E>(
+            this UniTask<Result<T, E>> asyncResult,
+            Func<Result<T, E>> fallbackFunc)
+        {
+            var result = await asyncResult;
+            return result.OrElse(fallbackFunc);
+        }
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise calls the `fallbackFunc` and returns its result.
+        /// </summary>
+        public static UniTask<Result<T, E>> OrElse<T, E>(
+            this Result<T, E> result,
+            Func<UniTask<Result<T, E>>> asyncFallbackFunc)
+        {
+            return result.IsSuccess ? UniTask.FromResult(result) : asyncFallbackFunc();
+        }
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise calls the `fallbackFunc` and returns its result.
+        /// </summary>
+        public static async UniTask<Result<T, E>> OrElse<T, E>(
+            this UniTask<Result<T, E>> asyncResult,
+            Func<UniTask<Result<T, E>>> asyncFallbackFunc)
+        {
+            var result = await asyncResult;
+            return result.IsSuccess ? result : await asyncFallbackFunc();
+        }
+#endif
+
+#if NOPE_AWAITABLE
+        // --- Awaitable Async Methods (OrElse) ---
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise calls the `fallbackFunc` and returns its result.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> OrElse<T, E>(
+            this Awaitable<Result<T, E>> asyncResult,
+            Func<Result<T, E>> fallbackFunc)
+        {
+            var result = await asyncResult;
+            return result.OrElse(fallbackFunc);
+        }
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise calls the `fallbackFunc` and returns its result.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> OrElse<T, E>(
+            this Result<T, E> result,
+            Func<Awaitable<Result<T, E>>> asyncFallbackFunc)
+        {
+            if (result.IsSuccess) return result;
+            return await asyncFallbackFunc();
+        }
+
+        /// <summary>
+        /// Returns the result if it is `Success`; otherwise calls the `fallbackFunc` and returns its result.
+        /// </summary>
+        public static async Awaitable<Result<T, E>> OrElse<T, E>(
+            this Awaitable<Result<T, E>> asyncResult,
+            Func<Awaitable<Result<T, E>>> asyncFallbackFunc)
+        {
+            var result = await asyncResult;
+            if (result.IsSuccess) return result;
+            return await asyncFallbackFunc();
+        }
+#endif
+    }
+}

--- a/Packages/Unity-NOPE/Runtime/Core/Result/ResultExtensions.OrElse.cs.meta
+++ b/Packages/Unity-NOPE/Runtime/Core/Result/ResultExtensions.OrElse.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 94f2d5e1ede4c4cdc893624f614eb8c0

--- a/Packages/Unity-NOPE/package.json
+++ b/Packages/Unity-NOPE/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kwanjoong.nope",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "displayName": "Unity NOPE",
   "description": "No Overused Possibly Evil exceptions.",
   "unity": "2022.3",


### PR DESCRIPTION
Introduces fallback extensions for Maybe and Result API:
- Implements OrElse and Or methods for enhanced error handling
- Converts Maybe to Result with ToResult method
- Extensive unit tests to ensure reliable operation and coverage

Updates documentation to include examples demonstrating the new fallback functionality.

Bumps package version to 1.4.0 to reflect new features and improvements.