### PR TITLE
Bumps package version to 1.4.1 for error propagation fix

### DIFF
--- a/Packages/Unity-NOPE/Runtime/Core/Result/Result.Combine.Sync.cs
+++ b/Packages/Unity-NOPE/Runtime/Core/Result/Result.Combine.Sync.cs
@@ -80,9 +80,11 @@ namespace NOPE.Runtime.Core.Result
         public static Result<T[], E> CombineValues<T, E>(
             params Result<T, E>[] results)
         {
-            var firstFail = results.FirstOrDefault(r => r.IsFailure);
-            if (firstFail.IsFailure)
-                return firstFail.Error;
+            foreach (var result in results)
+            {
+                if (result.IsFailure)
+                    return result.Error;
+            }
 
             var values = results.Select(r => r.Value).ToArray();
             return values;
@@ -93,9 +95,11 @@ namespace NOPE.Runtime.Core.Result
         /// </summary>
         public static Result<Unit, E> Combine<E>(params Result<Unit, E>[] results)
         {
-            var firstFail = results.FirstOrDefault(r => r.IsFailure);
-            if (firstFail.IsFailure)
-                return Result<Unit, E>.Failure(firstFail.Error);
+            foreach (var result in results)
+            {
+                if (result.IsFailure)
+                    return Result<Unit, E>.Failure(result.Error);
+            }
 
             return Result<Unit, E>.Success(Unit.Value);
         }

--- a/Packages/Unity-NOPE/package.json
+++ b/Packages/Unity-NOPE/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kwanjoong.nope",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "displayName": "Unity NOPE",
   "description": "No Overused Possibly Evil exceptions.",
   "unity": "2022.3",


### PR DESCRIPTION
Increments the package version to reflect a fix addressing error propagation issues in result combination methods.

Ensures that the latest changes related to more robust error handling are accurately signaled to users and dependents.